### PR TITLE
修复在主页中文的情况下，点进文档自动跳转英语的情况

### DIFF
--- a/docs/.vitepress/zh.mts
+++ b/docs/.vitepress/zh.mts
@@ -20,7 +20,7 @@ export const zhConfig = defineConfig({
     nav: [
       {
         text: "文档",
-        link: "/getting-started"
+        link: "/zh/getting-started"
       },
       {
         text: "API参考",
@@ -28,7 +28,7 @@ export const zhConfig = defineConfig({
       },
       {
         text: "项目成员",
-        link: "/members"
+        link: "/zh/members"
       },
       {
         text: "赞助",


### PR DESCRIPTION
### 当主页为中文时，点进文档后会出现自动跳转至英文文档的情况

## 另一已知问题：
### 点进”api参考“板块会404，看文件结构是还未动工，望早日开工